### PR TITLE
chore: Set default loglevel to INFO

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ const (
 	queryMetadataOperations = "round%28sum%20by%28target%2Cjobid%29%28irate%28lustre_job_stats_total[__TIME_RANGE__]%29%3E=1%29%29"
 	queryJobReadBytes       = "sum%20by%28jobid%29%28irate%28lustre_job_read_bytes_total[__TIME_RANGE__]%29!=0%29"
 	queryJobWriteBytes      = "sum%20by%28jobid%29%28irate%28lustre_job_write_bytes_total[__TIME_RANGE__]%29!=0%29"
-	defaultLogLevel         = "ERROR"
+	defaultLogLevel         = "INFO"
 	defaultPort             = "9846"
 	defaultRequestTimeout   = 15
 	defaultTimeRange        = "1m"


### PR DESCRIPTION
Logging at level INFO seems way more common.

This also brings this in sync with the claim in README.md.