### PR TITLE
refactor: extract resolveProcInfo() from duplicated proc_name.uid parsing

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -54,6 +54,12 @@ type throughputInfo struct {
 	throughput float64
 }
 
+type procInfo struct {
+	procName  string
+	userName  string
+	groupName string
+}
+
 func newGaugeVecMetric(namespace string, metricName string, docString string, constLabels []string) *prometheus.GaugeVec {
 	return prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -280,40 +286,16 @@ func (e *exporter) buildLustreMetadataMetrics(jobs []jobInfo, users userInfoMap,
 
 		} else { // Should look like process name with UID (proc_name.uid)
 
-			fields := strings.Split(metadataInfo.jobid, ".")
-			lenFields := len(fields)
-
-			var procName string
-			var uid int
-
-			if lenFields < 2 {
-				log.Warning("Insufficient Lustre Jobstats procname_uid fields found in jobid: ", metadataInfo.jobid)
-				continue
-			}
-
-			// procName is all fields except the last, joined by "."
-			procName = strings.Join(fields[:lenFields-1], ".")
-			// uid is the last field
-			uid, err = strconv.Atoi(fields[lenFields-1])
+			info, err := resolveProcInfo(metadataInfo.jobid, users, groups)
 			if err != nil {
-				log.Warning("Failed to parse uid from fields: ", fields)
 				return err
 			}
-
-			userInfo, ok := users[uid]
-			if !ok {
-				log.Warning("uid not found in users map: ", uid)
-				continue
-			}
-
-			groupInfo, ok := groups[userInfo.gid]
-			if !ok {
-				log.Warning("gid not found in groups map: ", userInfo.gid)
+			if info == nil {
 				continue
 			}
 
 			e.procMetadataOperationsMetric.WithLabelValues(
-				procName, groupInfo.group, userInfo.user, metadataInfo.target).Add(float64(metadataInfo.operations))
+				info.procName, info.groupName, info.userName, metadataInfo.target).Add(float64(metadataInfo.operations))
 		}
 	}
 
@@ -380,43 +362,61 @@ func (e *exporter) buildLustreThroughputMetrics(jobs []jobInfo, users userInfoMa
 
 		} else { // Should look like process name with UID (proc_name.uid)
 
-			fields := strings.Split(thInfo.jobid, ".")
-			lenFields := len(fields)
-
-			var procName string
-			var uid int
-
-			if lenFields < 2 {
-				log.Warning("Insufficient Lustre Jobstats procname_uid fields found in jobid: ", thInfo.jobid)
-				continue
-			}
-
-			// procName is all fields except the last, joined by "."
-			procName = strings.Join(fields[:lenFields-1], ".")
-			// uid is the last field
-			uid, err = strconv.Atoi(fields[lenFields-1])
+			info, err := resolveProcInfo(thInfo.jobid, users, groups)
 			if err != nil {
-				log.Warning("Failed to parse uid from fields: ", fields)
 				return err
 			}
-
-			userInfo, ok := users[uid]
-			if !ok {
-				log.Warning("uid not found in users map: ", uid)
+			if info == nil {
 				continue
 			}
 
-			groupInfo, ok := groups[userInfo.gid]
-			if !ok {
-				log.Warning("gid not found in groups map: ", userInfo.gid)
-				continue
-			}
-
-			procMetric.WithLabelValues(procName, groupInfo.group, userInfo.user).Add(thInfo.throughput)
+			procMetric.WithLabelValues(info.procName, info.groupName, info.userName).Add(thInfo.throughput)
 		}
 	}
 
 	return nil
+}
+
+// resolveProcInfo parses a "procname.uid" jobid and resolves the UID to
+// user and group information via the provided lookup maps.
+// Returns (nil, nil) when the entry should be skipped (insufficient fields,
+// unknown UID or GID), and (nil, err) on fatal parse errors (malformed UID).
+func resolveProcInfo(jobid string, users userInfoMap, groups groupInfoMap) (*procInfo, error) {
+
+	fields := strings.Split(jobid, ".")
+	lenFields := len(fields)
+
+	if lenFields < 2 {
+		log.Warning("Insufficient Lustre Jobstats procname_uid fields found in jobid: ", jobid)
+		return nil, nil
+	}
+
+	// procName is all fields except the last, joined by "."
+	procName := strings.Join(fields[:lenFields-1], ".")
+	// uid is the last field
+	uid, err := strconv.Atoi(fields[lenFields-1])
+	if err != nil {
+		log.Warning("Failed to parse uid from fields: ", fields)
+		return nil, err
+	}
+
+	userInfo, ok := users[uid]
+	if !ok {
+		log.Warning("uid not found in users map: ", uid)
+		return nil, nil
+	}
+
+	groupInfo, ok := groups[userInfo.gid]
+	if !ok {
+		log.Warning("gid not found in groups map: ", userInfo.gid)
+		return nil, nil
+	}
+
+	return &procInfo{
+		procName:  procName,
+		userName:  userInfo.user,
+		groupName: groupInfo.group,
+	}, nil
 }
 
 func parseLustreMetadataOperations(content *[]byte) (*[]metadataInfo, error) {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -64,6 +64,84 @@ func TestParseLustreMetadataOperations(t *testing.T) {
 
 }
 
+func TestResolveProcInfo(t *testing.T) {
+
+	users := userInfoMap{
+		1001: userInfo{user: "alice", uid: 1001, gid: 100},
+		1002: userInfo{user: "carol", uid: 1002, gid: 999}, // GID not in groups
+	}
+
+	groups := groupInfoMap{
+		100: groupInfo{group: "staff", gid: 100},
+	}
+
+	// Simple procname.uid — verify all returned fields
+	info, err := resolveProcInfo("cp.1001", users, groups)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("Expected non-nil procInfo for cp.1001")
+	}
+	if info.procName != "cp" {
+		t.Errorf("Expected procName 'cp', got '%s'", info.procName)
+	}
+	if info.userName != "alice" {
+		t.Errorf("Expected userName 'alice', got '%s'", info.userName)
+	}
+	if info.groupName != "staff" {
+		t.Errorf("Expected groupName 'staff', got '%s'", info.groupName)
+	}
+
+	// Dotted procname — only procName parsing differs
+	info, err = resolveProcInfo("my.app.1001", users, groups)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("Expected non-nil procInfo for my.app.1001")
+	}
+	if info.procName != "my.app" {
+		t.Errorf("Expected procName 'my.app', got '%s'", info.procName)
+	}
+
+	// No dot separator → skip (nil, nil)
+	info, err = resolveProcInfo("nodot", users, groups)
+	if err != nil {
+		t.Errorf("Unexpected error for 'nodot': %v", err)
+	}
+	if info != nil {
+		t.Error("Expected nil procInfo for 'nodot'")
+	}
+
+	// Non-numeric UID → error
+	info, err = resolveProcInfo("cp.notanumber", users, groups)
+	if err == nil {
+		t.Error("Expected error for non-numeric UID")
+	}
+	if info != nil {
+		t.Error("Expected nil procInfo for non-numeric UID")
+	}
+
+	// Unknown UID → skip (nil, nil)
+	info, err = resolveProcInfo("cp.9999", users, groups)
+	if err != nil {
+		t.Errorf("Unexpected error for unknown UID: %v", err)
+	}
+	if info != nil {
+		t.Error("Expected nil procInfo for unknown UID")
+	}
+
+	// Known UID but unknown GID → skip (nil, nil)
+	info, err = resolveProcInfo("cp.1002", users, groups)
+	if err != nil {
+		t.Errorf("Unexpected error for unknown GID: %v", err)
+	}
+	if info != nil {
+		t.Error("Expected nil procInfo for unknown GID")
+	}
+}
+
 func TestParseLustreTotalBytes(t *testing.T) {
 
 	var data string = `{"status":"success","data":{"resultType":"vector","result":[


### PR DESCRIPTION
Extract the proc_name.uid parsing and UID/GID resolution logic that was duplicated in buildLustreMetadataMetrics() and buildLustreThroughputMetrics() into a shared resolveProcInfo() helper function.

The helper uses a (nil, nil) vs (nil, err) return convention to preserve the original continue vs return semantics:
- (nil, nil): skip entry (insufficient fields, unknown UID/GID)
- (nil, err): fatal parse error (malformed UID)
- (*procInfo, nil): success

Add unit tests for resolveProcInfo() covering all code paths.

LLM assistance: Claude Opus 4.6 (via GitHub Copilot coding agent)